### PR TITLE
[FEAT] First Aid 페이지 구현 및 API 연결 

### DIFF
--- a/app/api/first-aid/route.ts
+++ b/app/api/first-aid/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { symptomType, symptomDetail } = body;
+
+    if (!symptomType || !symptomDetail) {
+      return NextResponse.json(
+        { error: 'symptomType 혹은 symptomDetail을 입력해야 합니다.' },
+        { status: 400 },
+      );
+    }
+
+    const response = await fetch('http://34.9.101.87:8080/first-aid/chat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ emergencyType: symptomType, userMessage: symptomDetail }),
+    });
+
+    const responseData = await response.json();
+
+    if (!response.ok || responseData.result !== 'SUCCESS') {
+      return NextResponse.json(
+        { error: responseData.message || 'POST 요청에 실패했습니다.' },
+        { status: response.status },
+      );
+    }
+
+    return NextResponse.json({ result: responseData.data }, { status: 200 });
+  } catch (error) {
+    console.error('Error in POST request:', error);
+    return new Response('Internal Server Error', { status: 500 });
+  }
+}

--- a/app/first-aid/page.tsx
+++ b/app/first-aid/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSymptomStore } from '@/src/features/firstAid/store/useSymptomStore';
+import { postFirstAid } from '@/src/features/firstAid/api/firstAid';
+import { useHydration } from '@/src/shared/hooks/useHydration';
+
+interface FirstAidResult {
+  content: string;
+  recommendedAction: string;
+  confidence: number;
+}
+
+export default function FirstAidPage() {
+  const hydrated = useHydration();
+  const { symptomType, symptomDetail } = useSymptomStore();
+  const [result, setResult] = useState<FirstAidResult | string | null>(null);
+
+  useEffect(() => {
+    if (!hydrated || !symptomType || !symptomDetail) return;
+
+    const postData = async () => {
+      try {
+        const res = await postFirstAid({ symptomType, symptomDetail });
+        setResult(res.result);
+      } catch (e) {
+        setResult('에러가 발생했어요. 잠시 후 다시 시도해주세요.');
+        console.error(e);
+      }
+    };
+
+    postData();
+  }, [hydrated, symptomType, symptomDetail]);
+
+  if (!hydrated) {
+    return (
+      <div className='flex min-h-screen items-center justify-center text-lg text-gray-600'>
+        로딩 중입니다...
+      </div>
+    );
+  }
+
+  if (!symptomType || !symptomDetail) {
+    return (
+      <div className='flex min-h-screen items-center justify-center px-4 text-center text-red-500'>
+        증상 정보가 없습니다. <br /> 처음부터 다시 입력해주세요.
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12'>
+      <div className='w-full max-w-xl space-y-6 rounded-2xl bg-white p-6 shadow-xl'>
+        <h1 className='text-2xl font-bold text-blue-700'>AI 응급처치 결과</h1>
+
+        {result ? (
+          typeof result === 'object' ? (
+            <div className='space-y-4'>
+              <div className='rounded-lg border bg-blue-50 p-4'>
+                <h2 className='mb-1 font-semibold text-gray-700'>내용</h2>
+                <p className='text-gray-800'>{result.content}</p>
+              </div>
+
+              <div className='rounded-lg border bg-green-50 p-4'>
+                <h2 className='mb-1 font-semibold text-gray-700'>추천 행동</h2>
+                <p className='font-medium text-green-800'>{result.recommendedAction}</p>
+              </div>
+
+              <div>
+                <h2 className='mb-2 font-semibold text-gray-700'>신뢰도</h2>
+                <div className='h-3 w-full rounded-full bg-gray-200'>
+                  <div
+                    className='h-3 rounded-full bg-green-500'
+                    style={{ width: `${result.confidence * 100}%` }}
+                  ></div>
+                </div>
+                <p className='mt-1 text-sm text-gray-600'>
+                  {(result.confidence * 100).toFixed(1)}%
+                </p>
+              </div>
+            </div>
+          ) : (
+            <div className='rounded-lg border border-red-300 bg-red-100 p-4 text-sm whitespace-pre-wrap text-red-800'>
+              {result}
+            </div>
+          )
+        ) : (
+          <div className='animate-pulse text-gray-600'>AI 분석 중입니다...</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "next": "15.3.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-icons:
         specifier: ^5.5.0
         version: 5.5.0(react@19.1.0)
+      zustand:
+        specifier: ^5.0.4
+        version: 5.0.4(@types/react@19.0.10)(react@19.1.0)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -1687,6 +1690,24 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@5.0.4:
+    resolution: {integrity: sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -3480,3 +3501,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.4(@types/react@19.0.10)(react@19.1.0):
+    optionalDependencies:
+      '@types/react': 19.0.10
+      react: 19.1.0

--- a/src/features/firstAid/api/firstAid.ts
+++ b/src/features/firstAid/api/firstAid.ts
@@ -1,11 +1,11 @@
 interface FirstAidRequest {
-  emergencyType: string;
-  userMessage: string;
+  symptomType: string;
+  symptomDetail: string;
 }
 
 export const postFirstAid = async (formData: FirstAidRequest) => {
   try {
-    const response = await fetch('/api/aiChat', {
+    const response = await fetch('/api/first-aid', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -15,10 +15,11 @@ export const postFirstAid = async (formData: FirstAidRequest) => {
 
     if (!response.ok) {
       const errorData = await response.json();
-      throw new Error(errorData.errorMessage || 'first aid POST 요청에 실패했습니다.');
+      throw new Error(errorData.error || 'first aid POST 요청에 실패했습니다.');
     }
 
-    return await response.json();
+    const data = await response.json();
+    return data;
   } catch (error: any) {
     throw new Error(error.message || 'first aid POST 요청에 실패했습니다.');
   }

--- a/src/features/firstAid/store/useSymptomStore.ts
+++ b/src/features/firstAid/store/useSymptomStore.ts
@@ -1,15 +1,23 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface SymptomState {
   symptomType: string;
   symptomDetail: string;
-  setSymptomData: (symptomType: string, symptomDetail: string) => void;
+  setSymptomData: (type: string, detail: string) => void;
   resetSymptom: () => void;
 }
 
-export const useSymptomStore = create<SymptomState>((set) => ({
-  symptomType: '',
-  symptomDetail: '',
-  setSymptomData: (symptomType, symptomDetail) => set({ symptomType, symptomDetail }),
-  resetSymptom: () => set({ symptomType: '', symptomDetail: '' }),
-}));
+export const useSymptomStore = create<SymptomState>()(
+  persist(
+    (set) => ({
+      symptomType: '',
+      symptomDetail: '',
+      setSymptomData: (symptomType, symptomDetail) => set({ symptomType, symptomDetail }),
+      resetSymptom: () => set({ symptomType: '', symptomDetail: '' }),
+    }),
+    {
+      name: 'symptom-storage',
+    },
+  ),
+);

--- a/src/features/firstAid/store/useSymptomStore.ts
+++ b/src/features/firstAid/store/useSymptomStore.ts
@@ -1,15 +1,15 @@
 import { create } from 'zustand';
 
 interface SymptomState {
-  selectedSymptom: string;
-  detail: string;
-  setSymptomData: (symptom: string, detail: string) => void;
+  symptomType: string;
+  symptomDetail: string;
+  setSymptomData: (symptomType: string, symptomDetail: string) => void;
   resetSymptom: () => void;
 }
 
 export const useSymptomStore = create<SymptomState>((set) => ({
-  selectedSymptom: '',
-  detail: '',
-  setSymptomData: (selectedSymptom, detail) => set({ selectedSymptom, detail }),
-  resetSymptom: () => set({ selectedSymptom: '', detail: '' }),
+  symptomType: '',
+  symptomDetail: '',
+  setSymptomData: (symptomType, symptomDetail) => set({ symptomType, symptomDetail }),
+  resetSymptom: () => set({ symptomType: '', symptomDetail: '' }),
 }));

--- a/src/features/firstAid/store/useSymptomStore.ts
+++ b/src/features/firstAid/store/useSymptomStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface SymptomState {
+  selectedSymptom: string;
+  detail: string;
+  setSymptomData: (symptom: string, detail: string) => void;
+  resetSymptom: () => void;
+}
+
+export const useSymptomStore = create<SymptomState>((set) => ({
+  selectedSymptom: '',
+  detail: '',
+  setSymptomData: (selectedSymptom, detail) => set({ selectedSymptom, detail }),
+  resetSymptom: () => set({ selectedSymptom: '', detail: '' }),
+}));

--- a/src/shared/hooks/useHydration.ts
+++ b/src/shared/hooks/useHydration.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useHydration() {
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  return hydrated;
+}

--- a/src/shared/ui/Dropdown.tsx
+++ b/src/shared/ui/Dropdown.tsx
@@ -11,7 +11,7 @@ export default function Dropdown({ direction = 'bottom', children }: DropdownPro
 
   return (
     <div
-      className={`absolute left-1/2 -translate-x-1/2 ${positionClass} z-50 w-48 rounded-md border bg-white shadow-md ${animationClass}`}
+      className={`absolute left-1/2 -translate-x-1/2 ${positionClass} z-50 w-48 rounded-md border bg-white shadow-md ${animationClass} cursor-pointer`}
     >
       {children}
     </div>

--- a/src/widgets/bottomNavigateBar/model/data.ts
+++ b/src/widgets/bottomNavigateBar/model/data.ts
@@ -1,0 +1,19 @@
+export const MENU_ITEMS = [
+  { code: 'help', label: 'Help' },
+  { code: 'emergency', label: 'Emergency Call' },
+  { code: 'contact', label: 'Contact Us' },
+];
+
+export const SYMPTOMS = [
+  { code: 'BLEEDING', label: 'BLEEDING' },
+  { code: 'BURNS', label: 'BURNS' },
+  { code: 'FRACTURE', label: 'FRACTURE' },
+  { code: 'ALLERGIC_REACTION', label: 'ALLERGIC REACTION' },
+  { code: 'SEIZURE', label: 'SEIZURE' },
+  { code: 'HEATSTROKE', label: 'HEATSTROKE' },
+  { code: 'HYPOTHERMIA', label: 'HYPOTHERMIA' },
+  { code: 'POISONING', label: 'POISONING' },
+  { code: 'BREATHING_DIFFICULTY', label: 'BREATHING DIFFICULTY' },
+  { code: 'ANIMAL_BITE', label: 'ANIMAL_BITE' },
+  { code: 'FALL_INJURY', label: 'FALL_INJURY' },
+];

--- a/src/widgets/bottomNavigateBar/ui/BottomNavigateBar.tsx
+++ b/src/widgets/bottomNavigateBar/ui/BottomNavigateBar.tsx
@@ -8,17 +8,43 @@ import { FaHome, FaRegHospital } from 'react-icons/fa';
 import { MdGTranslate } from 'react-icons/md';
 import { RiRobot3Line } from 'react-icons/ri';
 import { TiThMenu } from 'react-icons/ti';
+import { MENU_ITEMS, SYMPTOMS } from '../model/data';
+import { useSymptomStore } from '@/src/features/firstAid/store/useSymptomStore';
+import { useRouter } from 'next/navigation';
 
 const linkClassName =
-  'flex items-center justify-center rounded-full p-2 hover:scale-110 hover:bg-gray-200 transition-transform transition-colors duration-200 ease-in-out';
+  'flex items-center cursor-pointer justify-center rounded-full p-2 hover:scale-110 hover:bg-gray-200 transition-transform transition-colors duration-200 ease-in-out';
 
 export default function BottomNavigateBar() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [localSymptomType, setLocalSymptomType] = useState('');
+  const [localSymptomDetail, setLocalSymptomDetail] = useState('');
+
+  const { setSymptomData } = useSymptomStore();
+  const router = useRouter();
 
   const handleModal = () => setIsModalOpen((prev) => !prev);
-  const closeModal = () => setIsModalOpen(false);
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
   const handleMenu = () => setIsMenuOpen((prev) => !prev);
+
+  const handleSymptomChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setLocalSymptomType(e.target.value);
+  };
+
+  const handleTextareaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setLocalSymptomDetail(e.target.value);
+  };
+
+  const handleSubmit = () => {
+    setSymptomData(localSymptomType, localSymptomDetail);
+    closeModal();
+    router.push('/first-aid');
+  };
+
+  const isDisabled = !localSymptomType || !localSymptomDetail;
 
   return (
     <>
@@ -40,26 +66,48 @@ export default function BottomNavigateBar() {
           {isMenuOpen && (
             <Dropdown direction='top'>
               <ul className='p-2'>
-                <li className='p-2 hover:bg-gray-100'>돋움말</li>
-                <li className='p-2 hover:bg-gray-100'>비상전화</li>
-                <li className='p-2 hover:bg-gray-100'>문의하기</li>
+                {MENU_ITEMS.map((item) => (
+                  <li key={item.code} className='mb-2 hover:cursor-pointer hover:text-blue-500'>
+                    {item.label}
+                  </li>
+                ))}
               </ul>
             </Dropdown>
           )}
         </button>
       </div>
+
       {isModalOpen && (
         <Modal onClose={closeModal}>
-          <h2 className='mb-4 text-center text-xl font-bold'>증상을 설명해주세요.</h2>
+          <h2 className='mb-4 text-center text-xl font-bold'>Describe your symptom</h2>
+          <select
+            className='mb-4 w-full rounded-md border border-gray-300 p-2 text-sm focus:ring-2 focus:ring-blue-400 focus:outline-none'
+            onChange={handleSymptomChange}
+            value={localSymptomType}
+          >
+            <option value='' disabled>
+              Select symptom
+            </option>
+            {SYMPTOMS.map((symptom) => (
+              <option key={symptom.code} value={symptom.code}>
+                {symptom.label}
+              </option>
+            ))}
+          </select>
           <textarea
             className='mb-4 h-32 w-full resize-none rounded-md border border-gray-300 p-2 text-sm focus:ring-2 focus:ring-blue-400 focus:outline-none'
-            placeholder='증상을 입력하세요...'
+            placeholder='Describe your symptoms in detail'
+            value={localSymptomDetail}
+            onChange={handleTextareaChange}
           />
           <button
-            onClick={closeModal}
-            className='w-full rounded-md bg-blue-500 px-4 py-2 text-white transition-colors duration-200 hover:bg-blue-600'
+            disabled={isDisabled}
+            onClick={handleSubmit}
+            className={`w-full rounded-md px-4 py-2 text-white transition-colors duration-200 ${
+              isDisabled ? 'cursor-not-allowed bg-gray-300' : 'bg-blue-500 hover:bg-blue-600'
+            }`}
           >
-            확인
+            Submit
           </button>
         </Modal>
       )}


### PR DESCRIPTION
## 🚩 연관 이슈

closed #13 

## 📝 작업 내용
- First Aid 페이지 구현 및 API 연결 - 65f1715a945d03f93f38be8afd4508d3deacd568
- useSymptomStore 구현 (Zustand) - 2a43b19549a07fe4b9717faecb0ddfeec78376e3 , 035e082f163f1c3831ea715cc96972fbbfc03433


## ✨ 참고 사항
`FirstAidPage` 페이지에서 `useHydration` 훅을 사용하였습니다.
Next.js의 CSR과 SSR(의 차이로 인해 발생할 수 있는 초기 렌더링 불일치 문제(hydration mismatch)를 안전하게 방지하기 위해서입니다.

Next.js는 서버에서 HTML을 먼저 렌더링하고,  symptomType, symptomDetail (Zustand)은 Client에서만 상태가 관리됩니다.
하지만 이 상태는 server에서는 항상 비어 있어서(undefined) 서버에서는 symptom에 대한 정보가 없게 됩니다.
Client로 넘어와 상태가 채워지면 렌더링 결과가 <div>AI 분석 중...</div> 같은 것으로 바뀌고 결과적으로 React는 서버 렌더링 결과와 클라이언트 결과가 다르다고 판단하여 콘솔 경고를 나타내게 됩니다.

하지만 `useHydration` 훅을 사용할 경우 브라우저에서 hydration이 완료된 이후에만 본격적인 페이지가 렌더링되기 때문에, 서버에서의 예측 불가능한 상태값 접근이 없게 됩니다.


## ⏰ 현재 버그
X

## 🏞️ 스크린샷 (선택)

- 임시 UI (Refactoring 예정)
![image](https://github.com/user-attachments/assets/3b8280da-3ee4-4bc8-ac3c-6848a11615cd)


